### PR TITLE
Make Emacs P4 modes derive from prog-mode

### DIFF
--- a/editor-support/p4_14-mode.el
+++ b/editor-support/p4_14-mode.el
@@ -239,16 +239,12 @@
 (require 'xcscope)
 
 ;; Put everything together
-(defun p4_14-mode ()
+(define-derived-mode p4_14-mode prog-mode "P4_14"
   "Major mode for editing P4_14 programs"
-  (interactive)
-  (kill-all-local-variables)
-  (set-syntax-table p4_14-mode-syntax-table)
+  :syntax-table p4_14-mode-syntax-table
   (use-local-map p4_14-mode-map)
   (set (make-local-variable 'font-lock-defaults) '(p4_14-font-lock-keywords))
-  (set (make-local-variable 'indent-line-function) 'p4_14-indent-line)  
-  (setq major-mode 'p4_14-mode)
-  (setq mode-name "P4_14")
+  (set (make-local-variable 'indent-line-function) 'p4_14-indent-line)
   (setq imenu-generic-expression p4_14-imenu-generic-expression)
   ;; Setting this to nil causes indentation to use only space
   ;; characters, never tabs.

--- a/editor-support/p4_16-mode.el
+++ b/editor-support/p4_16-mode.el
@@ -213,16 +213,12 @@
 (require 'xcscope)
 
 ;; Put everything together
-(defun p4_16-mode ()
+(define-derived-mode p4_16-mode prog-mode "P4_16"
   "Major mode for editing P4_16 programs"
-  (interactive)
-  (kill-all-local-variables)
-  (set-syntax-table p4_16-mode-syntax-table)
+  :syntax-table p4_16-mode-syntax-table
   (use-local-map p4_16-mode-map)
   (set (make-local-variable 'font-lock-defaults) '(p4_16-font-lock-keywords))
-  (set (make-local-variable 'indent-line-function) 'p4_16-indent-line)  
-  (setq major-mode 'p4_16-mode)
-  (setq mode-name "P4_16")
+  (set (make-local-variable 'indent-line-function) 'p4_16-indent-line)
   (setq imenu-generic-expression p4_16-imenu-generic-expression)
   ;; Setting this to nil causes indentation to use only space
   ;; characters, never tabs.


### PR DESCRIPTION
Not sure if this is the best place to submit these. If not, where would be good? Ideally, these modes would be MELPA packages with their own repos which would make them much more accessible to the typical Emacs user. I'm not sure why it isn't - as I'm not the original author I haven't taken the liberty of creating such a package myself.

With regards to the patch. This is a minor change to derive the p4 modes from prog-mode. This way enabling the p4 mode also triggers all my generic programming config (such as line numbers and parentheses highlighting).