### PR TITLE
Update install-p4dev-v6.sh

### DIFF
--- a/bin/install-p4dev-v6.sh
+++ b/bin/install-p4dev-v6.sh
@@ -368,6 +368,9 @@ pip -V  || echo "No such command in PATH: pip"
 pip2 -V || echo "No such command in PATH: pip2"
 pip3 -V || echo "No such command in PATH: pip3"
 
+# On new systems if you have never checked repos you should do that first
+sudo apt-get --yes update
+
 # Install a few packages (vim is not strictly necessary -- installed for
 # my own convenience):
 sudo apt-get --yes install git vim


### PR DESCRIPTION
Added an `apt-get update` to the script to prevent an error encounter on new machines where the scrip hangs when it can't find `python3-pip`

```
+ sudo apt-get --yes install python3-pip
Reading package lists...
Building dependency tree...
Reading state information...
Package python3-pip is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'python3-pip' has no installation candidate
```